### PR TITLE
Non-standard button fixes

### DIFF
--- a/module/src/cleaner-sheet-title-bar.js
+++ b/module/src/cleaner-sheet-title-bar.js
@@ -14,29 +14,16 @@ function cleanDocumentHeader(app, html) {
     const windowHeader = html[0].querySelector("header.window-header");
     if (windowHeader === null || windowHeader === undefined) return;
 
-    const headerButtons = windowHeader.querySelectorAll("a.header-button");
-    if (headerButtons === null
-        || headerButtons === undefined
-        || (Array.isArray(headerButtons) && !headerButtons.length)) return;
-
-    for (let headerButton of headerButtons) {
-        removeTextFromButton(headerButton);
-    }
-
     setTimeout(() => {
-        handlePopoutModule(windowHeader);
+        const headerButtons = windowHeader.querySelectorAll("a");
+        if (headerButtons === null
+            || headerButtons === undefined
+            || (Array.isArray(headerButtons) && !headerButtons.length)) return;
+
+        for (let headerButton of headerButtons) {
+            removeTextFromButton(headerButton);
+        }
     }, 100);
-}
-
-function handlePopoutModule(windowHeader) {
-    if (game.modules.get("popout")) {
-        const popoutButton = windowHeader.querySelector("a[id*=popout]");
-        if (popoutButton === null
-            || popoutButton === undefined
-            || (Array.isArray(popoutButton) && !popoutButton.length)) return;
-
-        removeTextFromButton(popoutButton);
-    }
 }
 
 Hooks.on('renderApplication', cleanDocumentHeader);


### PR DESCRIPTION
Couple of fixes:

Replaced the `a.header-button` selector with just `a` - We want to affect all buttons in the header, not just ones that apply the `header-button` class (which some modules do not do, such as Popout, DAE, and GM Notes). There are no `a` tags in the header bar except these buttons, so there's no reason to limit the selection.

Wrapped all the button handling in a `setTimeout` of 100, which removes the need for a special handler for Popout and fixes cases where DAE (and probably others) are added after this module's script is ran, preventing them from being condensed.